### PR TITLE
add workflow for python deployment to pypi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,31 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@
 import io
 import os
 import sys
+import subprocess
 from shutil import rmtree
 
 from setuptools import find_packages, setup, Command
@@ -18,7 +19,7 @@ URL = 'https://github.com/notAI-tech/fastPunct'
 EMAIL = 'kodalihari.619@gmail.com'
 AUTHOR = 'Hari Krishna Sai Kodali'
 REQUIRES_PYTHON = '>=3.5.0'
-VERSION = '1.0.2'
+VERSION = subprocess.run(['git', 'describe', '--tags'], stdout=subprocess.PIPE).stdout.decode("utf-8").strip()
 
 # What packages are required for this module to be executed?
 REQUIRED = [


### PR DESCRIPTION
fixes #23

The edits made were not refreshed, so I thought of adding automation as well in the script
just add pypi password and username in your settings secrets
This will make updation to pypi much easier process

check short video for implementation
[GitHub Actions to publish releases to pip](https://www.youtube.com/watch?v=U-aIPTS580s&ab_channel=CFEngine)